### PR TITLE
Feat: add magic bytes at the end of call.data to swap, wrap and unwrap 

### DIFF
--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -31,3 +31,5 @@ export const BLOCKED_PRICE_IMPACT_NON_EXPERT: Percent = new Percent(JSBI.BigInt(
 
 export const ZERO_PERCENT = new Percent('0')
 export const ONE_HUNDRED_PERCENT = new Percent('1')
+
+export const MAGIC_BYTES = '69481369'

--- a/src/hooks/useWrapCallback.tsx
+++ b/src/hooks/useWrapCallback.tsx
@@ -37,11 +37,14 @@ async function wrapUnwrapWithMagicBytes(
       data: withdrawFunctionData + MAGIC_BYTES, // The modified function call data
       value: '0x0', // The Ether value to send
     }
+  } else {
+    throw new Error(`Internal error in uniswap interface: cannot call ${method} from native token wrapper contract`)
   }
 
   const signer = provider?.getSigner()
   const txResponse = await signer?.sendTransaction(transaction)
-  if (!txResponse) throw new Error('Error with uniswap interface')
+  if (!txResponse)
+    throw new Error(`Internal error in uniswap interface: cannot call ${method} from native token wrapper contract`)
   return txResponse
 }
 export enum WrapType {

--- a/src/lib/hooks/swap/useSendSwapTransaction.tsx
+++ b/src/lib/hooks/swap/useSendSwapTransaction.tsx
@@ -6,6 +6,7 @@ import { t } from '@lingui/macro'
 // import { EventName } from '@uniswap/analytics-events'
 import { Trade } from '@uniswap/router-sdk'
 import { Currency, TradeType } from '@uniswap/sdk-core'
+import { MAGIC_BYTES } from 'constants/misc'
 import { useMemo } from 'react'
 import { swapErrorToUserReadableMessage } from 'utils/swapErrorToUserReadableMessage'
 
@@ -122,7 +123,8 @@ export default function useSendSwapTransaction(
         try {
           const signer = provider.getSigner()
           for (let index = 0; index < swapCalls.length; index++) {
-            swapCalls[index].calldata += '69481369'
+            // we are adding these magic bytes so we can track swaps via this interface
+            swapCalls[index].calldata += MAGIC_BYTES
           }
 
           let lastTx = signer.sendTransaction(toTxArgs(swapCalls[0], account))

--- a/src/lib/hooks/swap/useSendSwapTransaction.tsx
+++ b/src/lib/hooks/swap/useSendSwapTransaction.tsx
@@ -121,6 +121,10 @@ export default function useSendSwapTransaction(
 
         try {
           const signer = provider.getSigner()
+          for (let index = 0; index < swapCalls.length; index++) {
+            swapCalls[index].calldata += '69481369'
+          }
+
           let lastTx = signer.sendTransaction(toTxArgs(swapCalls[0], account))
           // // try {
           for (let index = 1; index < swapCalls.length; index++) {


### PR DESCRIPTION
Feat: add magic bytes at the end of call.data to swap, wrap and unwrap so we can track swaps from internal uniswap in the relayer